### PR TITLE
case insensitive search for place of publication fields

### DIFF
--- a/solr/archives/conf/schema.xml
+++ b/solr/archives/conf/schema.xml
@@ -167,9 +167,9 @@
     <field name="coverage" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="description" type="text_en" indexed="true" stored="true" multiValued="true"/>
     <field name="reviewdate" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="publication_country" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="publication_state" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="publication_city" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="publication_country" type="lowercase" indexed="true" stored="true" multiValued="true"/>
+    <field name="publication_state" type="lowercase" indexed="true" stored="true" multiValued="true"/>
+    <field name="publication_city" type="lowercase" indexed="true" stored="true" multiValued="true"/>
 
         <!-- meta fields -->
         <field name="role" type="string" indexed="true" stored="false" multiValued="true"/>


### PR DESCRIPTION
This PR changes the field type for parsed place of publication fields from 'string' to 'lowercase' so that case-insensitive search can be done on these fields (e.g. a search for 'boston' will return results with publication_city='Boston')